### PR TITLE
Remove string case dependency

### DIFF
--- a/.github/actions/change_string_case/action.yml
+++ b/.github/actions/change_string_case/action.yml
@@ -1,0 +1,27 @@
+name: "change string case"
+description: "takes a string and "
+outputs:
+  lowercase:
+    description: "lower case string"
+    value: ${{steps.change_string_case.outputs.lowercase}}
+  uppercase:
+    description: "upper case string"
+    value: ${{steps.change_string_case.outputs.uppercase}}
+inputs:
+  string:
+    description: "input string"
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Change string case
+      id: change_string_case
+      run: |
+        set -o pipefail
+        LOWERCASE=$( echo "${{ inputs.string }}" | awk '{print tolower($0)}')
+        UPPERCASE=$( echo "${{ inputs.string }}" | awk '{print toupper($0)}')
+        echo "lowercase=$LOWERCASE" >> "$GITHUB_OUTPUT"
+        echo "uppercase=$UPPERCASE" >> "$GITHUB_OUTPUT"
+      shell: bash

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           path: ${{github.event.repository.name}}/pyproject.toml
       - id: lowercase_tags
-        uses: ASzc/change-string-case-action@v6
+        uses: ./.github/actions/change_string_case
         with:
           string: quay.io/${{ vars.QUAY_ORG }}/${{github.event.repository.name}}:${{steps.pyproject_toml_sha.outputs.sha}}
       - name: tag exists

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           path: ${{github.event.repository.name}}/pyproject.toml ${{github.event.repository.name}}/Dockerfile
       - id: lowercase_tags
-        uses: ASzc/change-string-case-action@v6
+        uses: ./.github/actions/change_string_case
         with:
           string: quay.io/${{ vars.QUAY_ORG }}/${{github.event.repository.name}}:${{steps.pyproject_toml_dockerfile_sha.outputs.sha}}
       - name: tag exists
@@ -59,7 +59,7 @@ jobs:
         with:
           path: ${{github.event.repository.name}}/pyproject.toml ${{github.event.repository.name}}/Dockerfile
       - id: lowercase_tags
-        uses: ASzc/change-string-case-action@v6
+        uses: ./.github/actions/change_string_case
         with:
           string: quay.io/${{ vars.QUAY_ORG }}/${{github.event.repository.name}}:${{steps.pyproject_toml_dockerfile_sha.outputs.sha}}
       - name: Login to quay.io
@@ -89,7 +89,7 @@ jobs:
         with:
           path: ${{github.event.repository.name}}/pyproject.toml ${{github.event.repository.name}}/Dockerfile
       - id: lowercase_tags
-        uses: ASzc/change-string-case-action@v6
+        uses: ./.github/actions/change_string_case
         with:
           string: quay.io/${{ vars.QUAY_ORG }}/${{github.event.repository.name}}:${{steps.pyproject_toml_dockerfile_sha.outputs.sha}}
       - name: Login to quay.io
@@ -119,7 +119,7 @@ jobs:
         with:
           path: ${{github.event.repository.name}}/pyproject.toml ${{github.event.repository.name}}/Dockerfile
       - id: lowercase_tags
-        uses: ASzc/change-string-case-action@v6
+        uses: ./.github/actions/change_string_case
         with:
           string: quay.io/${{ vars.QUAY_ORG }}/${{github.event.repository.name}}:${{steps.pyproject_toml_dockerfile_sha.outputs.sha}}
       - name: Login to quay.io


### PR DESCRIPTION
The repo currently uses a github action from the marketplace to convert string cases but I'd rather just have that as a local dependency since it should be easy enough to write.